### PR TITLE
fix: cards, images, and thumbnails

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -30,29 +30,74 @@
 		<!-- Open Graph / Facebook -->
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="Deep Sea Tactics" />
-		<meta property="og:url" content="https://willuhmjs.github.io/lhs-underwater-robotics/" />
+		<meta property="og:url" content="https://deepseatactics.com" />
 		<meta
 			property="og:description"
 			content="The website for Landstown High School's innovative underwater robotics team."
 		/>
 		<meta
 			property="og:image"
-			content="https://willuhmjs.github.io/lhs-underwater-robotics/images/jumbotron.png"
+			content="https://deepseatactics.com/images/jumbotron.png"
 		/>
 
 		<!-- Twitter -->
 		<meta property="twitter:card" content="summary_large_image" />
 		<meta property="twitter:title" content="Deep Sea Tactics" />
-		<meta property="twitter:url" content="https://willuhmjs.github.io/lhs-underwater-robotics/" />
+		<meta property="twitter:url" content="https://deepseatactics.com" />
 		<meta
 			property="twitter:description"
 			content="The website for Landstown High School's innovative underwater robotics team."
 		/>
 		<meta
 			twitter="og:image"
-			content="https://willuhmjs.github.io/lhs-underwater-robotics/images/jumbotron.png"
+			content="https://deepseatactics.com/images/jumbotron.png"
 		/>
 		<meta name="theme-color" content="#2C3289" />
+		<script type="application/ld+json">
+			{
+			 "@context": "http://schema.org",
+			 "@type": "Organization",
+			 "name": "Deep Sea Tactics",
+			 "logo": "https://deepseatactics.com/images/horizontal_logo.png",
+			 "mainEntityOfPage": "https://deepseatactics.com",
+			 "url": "https://deepseatactics.com",
+			 "description": "Landstown High School's innovative underwater robotics team.",
+			 "parentOrganization": 
+			 {
+				"@type": "Organization",
+			 	"name": "Landstown High School Governor's STEM and Technology Academy",
+			 	"image": "https://www.bjuarchitects.com/wp-content/uploads/2016/02/front.jpg",
+			 	"mainEntityOfPage": "https://en.wikipedia.org/wiki/Landstown_High_School",
+			 	"url": "https://landstownhs.vbschools.com/",
+				"address": "2001 Concert Drive Virginia Beach, VA 23456",
+				"naics": "611110",
+				"telephone": "(757) 648-5500",
+				"parentOrganization": 
+				{
+					"@type": "Organization",
+			 		"name": "Virginia Beach City Public Schools",
+			 		"image": "https://resources.finalsite.net/videos/t_video_vp9_1080/v1659644394/vbschoolscom/osxjcr2t4axfjrebs9t0/SchoolsCompilationWebsiteDraft2.webm",
+					"logo": "https://resources.finalsite.net/images/f_auto,q_auto,t_image_size_1/v1646127051/vbschoolscom/iribbwhg3k8eth5piggo/logo.png",
+			 		"mainEntityOfPage": "https://en.wikipedia.org/wiki/Virginia_Beach_City_Public_Schools",
+			 		"url": "https://www.vbschools.com/",
+					"address": "2512 George Mason Drive Virginia Beach, Virginia, 23456-0038 United States",
+					"location" 
+					{
+						"@type": "Place",
+						"address": "2512 George Mason Drive Virginia Beach, Virginia, 23456-0038 United States",
+						"geo":
+						{
+							"@type": "GeoCoordinates",
+							"latitude": 36.7517741,
+							"longitude": -76.0614749,
+						},
+					},
+					"naics": "611110",
+					"telephone": "(757) 263-1000",
+				},
+			 },
+			}
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/app.html
+++ b/src/app.html
@@ -53,51 +53,6 @@
 			content="https://deepseatactics.com/images/jumbotron.png"
 		/>
 		<meta name="theme-color" content="#2C3289" />
-		<script type="application/ld+json">
-			{
-			 "@context": "http://schema.org",
-			 "@type": "Organization",
-			 "name": "Deep Sea Tactics",
-			 "logo": "https://deepseatactics.com/images/horizontal_logo.png",
-			 "mainEntityOfPage": "https://deepseatactics.com",
-			 "url": "https://deepseatactics.com",
-			 "description": "Landstown High School's innovative underwater robotics team.",
-			 "parentOrganization": 
-			 {
-				"@type": "Organization",
-			 	"name": "Landstown High School Governor's STEM and Technology Academy",
-			 	"image": "https://www.bjuarchitects.com/wp-content/uploads/2016/02/front.jpg",
-			 	"mainEntityOfPage": "https://en.wikipedia.org/wiki/Landstown_High_School",
-			 	"url": "https://landstownhs.vbschools.com/",
-				"address": "2001 Concert Drive Virginia Beach, VA 23456",
-				"naics": "611110",
-				"telephone": "(757) 648-5500",
-				"parentOrganization": 
-				{
-					"@type": "Organization",
-			 		"name": "Virginia Beach City Public Schools",
-			 		"image": "https://resources.finalsite.net/videos/t_video_vp9_1080/v1659644394/vbschoolscom/osxjcr2t4axfjrebs9t0/SchoolsCompilationWebsiteDraft2.webm",
-					"logo": "https://resources.finalsite.net/images/f_auto,q_auto,t_image_size_1/v1646127051/vbschoolscom/iribbwhg3k8eth5piggo/logo.png",
-			 		"mainEntityOfPage": "https://en.wikipedia.org/wiki/Virginia_Beach_City_Public_Schools",
-			 		"url": "https://www.vbschools.com/",
-					"address": "2512 George Mason Drive Virginia Beach, Virginia, 23456-0038 United States",
-					"location" 
-					{
-						"@type": "Place",
-						"address": "2512 George Mason Drive Virginia Beach, Virginia, 23456-0038 United States",
-						"geo":
-						{
-							"@type": "GeoCoordinates",
-							"latitude": 36.7517741,
-							"longitude": -76.0614749,
-						},
-					},
-					"naics": "611110",
-					"telephone": "(757) 263-1000",
-				},
-			 },
-			}
-		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
narrow PR scope to expedite fix to links, etc,. to improve perceived legitimacy of link when sharing for fundraising

cherrypicked commit [4fbc123](https://github.com/deep-sea-tactics/website/commit/4fbc12316849e606feee465f40ef4707888ef43d) in [img+seo](https://github.com/deep-sea-tactics/website/tree/img+seo) and removed schema.org related content; maintained changes related to this PR.